### PR TITLE
E) Diffusive only

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1150,12 +1150,19 @@ Recycling has been implemented at the target, the SOL edge and the PFR edge.
 Each is off by default and must be activated with a separate flag. Each can be 
 assigned a separate recycle multiplier and recycle energy. 
 
-The chosen species must feature an outflow through the boundary - any cells
+Configuring thermal recycling
+^^^^^^^^^^^^^^^
+
+A simple and commonly used way to model recycling is to assume it is fully thermal,
+i.e. that every incident ion recombines into a neutral molecule and thermalises with the surface 
+before becoming re-emitted. Hermes-3 does not yet have a hydrogenic molecule model, and so 
+the molecules are assumed to instantly dissociate at the Franck-Condon dissociation temperature of 3.5eV.
+
+In order to set this up, the chosen species must feature an outflow through the boundary - any cells
 with an inflow have their recycling source set to zero. If a sheath boundary condition
 is enabled, then this is automatically satisfied at the target through the Bohm condition.
 If it is not enabled, then the target boundary must be set to `free_o2`, `free_o3` or `decaylength` to 
-allow an outflow. If SOL or PFR recycling is enabled, a `free_o2`, `free_o3` or `decaylength`on
-their respective boundaries is required at all times.
+allow an outflow. 
 
 The recycling component has a `species` option, that is a list of species
 to recycle. For each of the species in that list, `recycling` will look in
@@ -1193,6 +1200,40 @@ Each returning atom has an energy of 3.5eV:
    pfr_recycle_multiplier = 1 # Recycling fraction
    pfr_recycle_energy = 3.5   # Energy of recycled particles [eV]
 
+Allowing for fast recycling
+^^^^^^^^^^^^^^^
+
+In reality, a fraction of incident ions will undergo specular reflection off the surface and 
+preserve a fraction of their energy. In the popular Monte-Carlo neutral code EIRENE, the 
+fast recycling fraction and the energy reflection factor are provided by the `TRIM database <https://www.eirene.de/old_eirene/html/surface_data.html>`_
+as a function of incident angle, surface material and incident particle energy.
+Studies found that sheath acceleration can make the ion angle relatively consistent, e.g. 60 degrees; in (`Jae-Sun Park et al 2021 Nucl. Fusion 61 016021 <https://iopscience.iop.org/article/10.1088/1741-4326/abc1ce>`_).
+
+The recycled heat flux is:
+
+.. math::
+
+   \begin{aligned}
+   \Gamma_{E_{n}} &= R \times (R_{f} \alpha_{E} \Gamma_{E_{i}}^{sheath}  + (1 - R_{f}) T_{R} \Gamma_{N_{i}})) \\
+   \end{aligned}
+
+Where :math:`R` is the recycle multiplier, :math:`R_{f}` is the fast reflection fraction, :math:`\alpha_{E}` is the energy reflection factor,
+:math:`\Gamma_{E_{i}}^{sheath}` is the incident heat flux from the sheath boundary condition, :math:`T_{R}` is the recycle energy and :math:`\Gamma_{N_{i}}` is the incident ion flux.
+
+:math:`R_{f}` and :math:`\alpha_{E}` can be set as in the below example. They can also be set to different values for the SOL and PFR by replacing
+the word "target" with either "sol" or "pfr".
+
+.. code-block:: ini
+
+   [d+]
+   recycle_as = d         # Species to recycle as
+
+   target_recycle = true  
+   target_recycle_multiplier = 0.95 # Recycling fraction
+   target_recycle_energy = 3.5   # Energy of recycled particles [eV]
+   target_fast_recycle_energy_factor = 0.70
+   target_fast_recycle_fraction = 0.80
+
 Neutral pump
 ^^^^^^^^^^^^^^^
 
@@ -1204,8 +1245,8 @@ The pump requires wall recycling to be enabled on the relevant wall region.
 
 The particle loss rate :math:`\Gamma_{N_{n}}` is the sum of the incident ions that are not recycled and the 
 incident neutrals which are not reflected, both of which are controlled by the pump multiplier :math:`M_{p}` 
-which is set by the `pump_multiplier` option in the input file. The unrecycled ion flux :math:`\Gamma_{N_{i}}^{unrecycled}` is calculated exactly the same
-as for edge recycling but with `pump_multiplier` replacing the `recycle_multiplier`.
+which is set by the `pump_multiplier` option in the input file. The unrecycled ion flux :math:`\Gamma_{N_{i}}^{unrecycled}` is calculated using the recycling
+model and allows for either thermal or fast recycling, but with the difference that the `pump_multiplier` replaces the `recycle_multiplier`. 
 
 .. math::
 

--- a/examples/1D-hydrogen-equalT/BOUT.inp
+++ b/examples/1D-hydrogen-equalT/BOUT.inp
@@ -95,6 +95,8 @@ density_controller_p = 5e2
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]

--- a/examples/1D-hydrogen/BOUT.inp
+++ b/examples/1D-hydrogen/BOUT.inp
@@ -98,6 +98,8 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]

--- a/examples/1D-hydrogen/qn/BOUT.inp
+++ b/examples/1D-hydrogen/qn/BOUT.inp
@@ -100,6 +100,7 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]

--- a/examples/1D-neon-source/BOUT.inp
+++ b/examples/1D-neon-source/BOUT.inp
@@ -103,6 +103,8 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
@@ -169,6 +171,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+]
@@ -189,6 +193,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+2]
@@ -209,6 +215,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+3]
@@ -229,6 +237,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -251,8 +261,9 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
-
 diagnose = true
 
 [Nne+5]
@@ -273,6 +284,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -295,6 +308,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -317,6 +332,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -339,6 +356,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -361,6 +380,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true

--- a/examples/1D-neon/BOUT.inp
+++ b/examples/1D-neon/BOUT.inp
@@ -104,7 +104,9 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-target_recycle_multiplier = 1.0  # Recycling fraction
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]
 
@@ -168,6 +170,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nne+]
@@ -188,6 +192,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nne+2]
@@ -208,6 +214,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nne+3]
@@ -228,6 +236,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -250,6 +260,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -272,6 +284,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -294,6 +308,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -316,6 +332,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -338,6 +356,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -360,6 +380,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true

--- a/examples/1D-recycling/BOUT.inp
+++ b/examples/1D-recycling/BOUT.inp
@@ -101,6 +101,8 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true
 
 recycle_as = d
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]

--- a/examples/1D-recycling/cvode/BOUT.inp
+++ b/examples/1D-recycling/cvode/BOUT.inp
@@ -92,6 +92,8 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true
 
 recycle_as = d
+target_recycle = true
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]

--- a/examples/solkit-comparison/single-temperature/BOUT.inp
+++ b/examples/solkit-comparison/single-temperature/BOUT.inp
@@ -100,7 +100,9 @@ AA = 2
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-target_recycle_multiplier = 1.0  # Recycling fraction
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]
 

--- a/examples/solkit-comparison/two-temperatures/BOUT.inp
+++ b/examples/solkit-comparison/two-temperatures/BOUT.inp
@@ -100,7 +100,9 @@ AA = 2
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-target_recycle_multiplier = 1.0  # Recycling fraction
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]
 

--- a/examples/tokamak/recycling-dthe-drifts/BOUT.inp
+++ b/examples/tokamak/recycling-dthe-drifts/BOUT.inp
@@ -53,6 +53,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nd+]
@@ -89,6 +90,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = t
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nt+]
@@ -125,6 +127,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = he
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nhe+]

--- a/examples/tokamak/recycling-dthe/BOUT.inp
+++ b/examples/tokamak/recycling-dthe/BOUT.inp
@@ -53,6 +53,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nd+]
@@ -89,6 +90,7 @@ anomalous_chi = 1.0
 thermal_conduction = true
 
 recycle_as = t
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nt+]
@@ -125,6 +127,7 @@ anomalous_chi = 1.0
 thermal_conduction = true
 
 recycle_as = he
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true

--- a/examples/tokamak/recycling-dthene/BOUT.inp
+++ b/examples/tokamak/recycling-dthene/BOUT.inp
@@ -36,6 +36,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nd+]
@@ -76,6 +77,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = t
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nt+]
@@ -116,6 +118,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = he
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nhe+]
@@ -156,6 +159,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = ne
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+]

--- a/examples/tokamak/recycling/BOUT.inp
+++ b/examples/tokamak/recycling/BOUT.inp
@@ -59,6 +59,7 @@ anomalous_chi = 4
 thermal_conduction = true
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -51,19 +51,20 @@ private:
   BoutReal nn_floor; ///< Minimum Nn used when dividing NVn by Nn to get Vn.
 
   bool flux_limit; ///< Impose flux limiter?
-  bool particle_flux_limiter, heat_flux_limiter, momentum_flux_limiter; ///< Which limiters to impose
+  bool separate_heat_limiters;
+  bool particle_flux_limiter, heat_flux_limiter, conv_heat_flux_limiter, cond_heat_flux_limiter, momentum_flux_limiter; ///< Which limiters to impose
   BoutReal maximum_mfp; ///< Maximum mean free path for diffusion. 0.1 by default, -1 is off.
-  BoutReal flux_limit_alpha;
+  BoutReal flux_limit_alpha, cond_flux_limit_alpha, conv_flux_limit_alpha;
   BoutReal flux_limit_gamma;
   Field3D particle_flux_factor; ///< Particle flux scaling factor
   Field3D momentum_flux_factor;
-  Field3D heat_flux_factor;
+  Field3D heat_flux_factor, cond_heat_flux_factor, conv_heat_flux_factor;
 
   BoutReal flux_factor_timescale; ///< Timescale over which flux factors vary
   BoutReal flux_factor_time {-1.0}; ///< Last time the flux factors were updated
   Field3D particle_flux_avg; ///< Moving average flux factor
   Field3D momentum_flux_avg; ///< Moving average flux factor
-  Field3D heat_flux_avg; ///< Moving average flux factor
+  Field3D heat_flux_avg, cond_heat_flux_avg, conv_heat_flux_avg; ///< Moving average flux factor
 
   bool neutral_viscosity; ///< include viscosity?
 

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -43,13 +43,27 @@ private:
 
   Field3D Dnn; ///< Diffusion coefficient
   Field3D DnnNn, DnnPn, DnnTn, DnnNVn; ///< Used for operators
+  Field3D eta_n; ///< Viscosity
+  Field3D kappa_n; ///< Thermal conductivity
 
   bool sheath_ydown, sheath_yup;
 
   BoutReal nn_floor; ///< Minimum Nn used when dividing NVn by Nn to get Vn.
 
-  BoutReal flux_limit; ///< Diffusive flux limit
-  BoutReal diffusion_limit;    ///< Maximum diffusion coefficient
+  bool flux_limit; ///< Impose flux limiter?
+  bool particle_flux_limiter, heat_flux_limiter, momentum_flux_limiter; ///< Which limiters to impose
+  BoutReal maximum_mfp; ///< Maximum mean free path for diffusion. 0.1 by default, -1 is off.
+  BoutReal flux_limit_alpha;
+  BoutReal flux_limit_gamma;
+  Field3D particle_flux_factor; ///< Particle flux scaling factor
+  Field3D momentum_flux_factor;
+  Field3D heat_flux_factor;
+
+  BoutReal flux_factor_timescale; ///< Timescale over which flux factors vary
+  BoutReal flux_factor_time {-1.0}; ///< Last time the flux factors were updated
+  Field3D particle_flux_avg; ///< Moving average flux factor
+  Field3D momentum_flux_avg; ///< Moving average flux factor
+  Field3D heat_flux_avg; ///< Moving average flux factor
 
   bool neutral_viscosity; ///< include viscosity?
 

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -51,20 +51,13 @@ private:
   BoutReal nn_floor; ///< Minimum Nn used when dividing NVn by Nn to get Vn.
 
   bool flux_limit; ///< Impose flux limiter?
-  bool separate_heat_limiters;
-  bool particle_flux_limiter, heat_flux_limiter, conv_heat_flux_limiter, cond_heat_flux_limiter, momentum_flux_limiter; ///< Which limiters to impose
+  bool particle_flux_limiter, heat_flux_limiter, momentum_flux_limiter; ///< Which limiters to impose
   BoutReal maximum_mfp; ///< Maximum mean free path for diffusion. 0.1 by default, -1 is off.
-  BoutReal flux_limit_alpha, cond_flux_limit_alpha, conv_flux_limit_alpha, mom_flux_limit_alpha;
+  BoutReal flux_limit_alpha, heat_flux_limit_alpha, mom_flux_limit_alpha;
   BoutReal flux_limit_gamma;
   Field3D particle_flux_factor; ///< Particle flux scaling factor
   Field3D momentum_flux_factor;
-  Field3D heat_flux_factor, cond_heat_flux_factor, conv_heat_flux_factor;
-
-  BoutReal flux_factor_timescale; ///< Timescale over which flux factors vary
-  BoutReal flux_factor_time {-1.0}; ///< Last time the flux factors were updated
-  Field3D particle_flux_avg; ///< Moving average flux factor
-  Field3D momentum_flux_avg; ///< Moving average flux factor
-  Field3D heat_flux_avg, cond_heat_flux_avg, conv_heat_flux_avg; ///< Moving average flux factor
+  Field3D heat_flux_factor;
 
   bool neutral_viscosity; ///< include viscosity?
 

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -54,7 +54,7 @@ private:
   bool separate_heat_limiters;
   bool particle_flux_limiter, heat_flux_limiter, conv_heat_flux_limiter, cond_heat_flux_limiter, momentum_flux_limiter; ///< Which limiters to impose
   BoutReal maximum_mfp; ///< Maximum mean free path for diffusion. 0.1 by default, -1 is off.
-  BoutReal flux_limit_alpha, cond_flux_limit_alpha, conv_flux_limit_alpha;
+  BoutReal flux_limit_alpha, cond_flux_limit_alpha, conv_flux_limit_alpha, mom_flux_limit_alpha;
   BoutReal flux_limit_gamma;
   Field3D particle_flux_factor; ///< Particle flux scaling factor
   Field3D momentum_flux_factor;

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -48,6 +48,8 @@ private:
     /// Combination of recycling fraction and species change e.g h+ -> h2 results in 0.5 multiplier
     BoutReal target_multiplier, sol_multiplier, pfr_multiplier, pump_multiplier; 
     BoutReal target_energy, sol_energy, pfr_energy; ///< Energy of recycled particle (normalised to Tnorm)
+    BoutReal target_fast_recycle_fraction, pfr_fast_recycle_fraction, sol_fast_recycle_fraction;   ///< Fraction of ions undergoing fast reflection
+    BoutReal target_fast_recycle_energy_factor, sol_fast_recycle_energy_factor, pfr_fast_recycle_energy_factor;   ///< Fraction of energy retained by fast recycled neutrals
   };
 
   std::vector<RecycleChannel> channels; // Recycling channels
@@ -56,16 +58,17 @@ private:
   bool diagnose; ///< Save additional post-processing variables?
 
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
-  Field2D is_pump; ///< 1 = pump, 0 = no pump. Works only in SOL/PFR
+  Field3D energy_flow_ylow, energy_flow_xlow; ///< Cell edge fluxes used for calculating fast recycling energy source
+  Field3D particle_flow_xlow; ///< Radial wall particle fluxes for recycling calc. No need to get poloidal from here, it's calculated from sheath velocity
+
+  Field2D is_pump; ///< 1 = pump, 0 = no pump. Works only in SOL/PFR. Provided by user in grid file.
 
   // Recycling particle and energy sources for the different sources of recycling
   // Note that SOL, PFR and pump are not applicable to 1D
   Field3D target_recycle_density_source, target_recycle_energy_source; 
   Field3D wall_recycle_density_source, wall_recycle_energy_source;  ///< Recycling particle and energy sources for pfr + sol recycling
-  Field3D pump_recycle_density_source, pump_recycle_energy_source; 
+  Field3D pump_density_source, pump_energy_source;  ///< Recycling particle and energy sources for pump recycling
 
-  Field3D radial_particle_outflow, radial_energy_outflow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
-  
 };
 
 namespace {

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -86,6 +86,10 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
     .doc("Scale convection flux limiter")
     .withDefault(1.0);
 
+  mom_flux_limit_alpha = options["momentum_flux_limit_alpha"]
+    .doc("Scale momentum flux limiter")
+    .withDefault(1.0);
+
   flux_limit_gamma = options["flux_limit_gamma"]
     .doc("Higher values increase sharpness of flux limiting")
     .withDefault(2.0);
@@ -398,7 +402,7 @@ void NeutralMixed::finally(const Options& state) {
     Field3D momentum_limit = Pnlim;
 
     if (momentum_flux_limiter) {
-      momentum_flux_factor = pow(1. + pow(momentum_flux_abs / (flux_limit_alpha * momentum_limit),
+      momentum_flux_factor = pow(1. + pow(momentum_flux_abs / (mom_flux_limit_alpha * momentum_limit),
                                           flux_limit_gamma),
                                 -1./flux_limit_gamma);
     } else {

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -433,7 +433,7 @@ void NeutralMixed::finally(const Options& state) {
     Field3D conv_heat_limit = Pnlim * sqrt(2. * Tnlim / (PI * AA));
 
     if (heat_flux_limiter) {
-      conv_heat_flux_factor = pow(1. + pow(heat_flux_abs / (flux_limit_alpha * heat_limit),
+      conv_heat_flux_factor = pow(1. + pow(conv_heat_flux_abs / (conv_flux_limit_alpha * conv_heat_limit),
                                       flux_limit_gamma),
                               -1./flux_limit_gamma);
     } else {
@@ -441,13 +441,13 @@ void NeutralMixed::finally(const Options& state) {
     }
 
     // Conductive heat flux
-    Vector3D cond_heat_flux = (3./2) * Pn * particle_flux_factor * v_total + Pn * particle_flux_factor * v_perp;
+    Vector3D cond_heat_flux = kappa_n * Grad(Tn);
 
     Field3D cond_heat_flux_abs = sqrt(cond_heat_flux * cond_heat_flux);
     Field3D cond_heat_limit = Pnlim * sqrt(2. * Tnlim / (PI * AA));
 
     if (heat_flux_limiter) {
-      cond_heat_flux_factor = pow(1. + pow(heat_flux_abs / (flux_limit_alpha * heat_limit),
+      cond_heat_flux_factor = pow(1. + pow(cond_heat_flux_abs / (cond_flux_limit_alpha * cond_heat_limit),
                                       flux_limit_gamma),
                               -1./flux_limit_gamma);
     } else {

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -51,17 +51,40 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
                      .withDefault<bool>(true);
 
   flux_limit = options["flux_limit"]
-    .doc("Limit diffusive fluxes to fraction of thermal speed. <0 means off.")
-    .withDefault(0.2);
+    .doc("Use isotropic flux limiters?")
+    .withDefault(true);
 
-  diffusion_limit = options["diffusion_limit"]
-    .doc("Upper limit on diffusion coefficient [m^2/s]. <0 means off")
-    .withDefault(-1.0)
-    / (meters * meters / seconds); // Normalise
+  flux_factor_timescale = options["flux_factor_timescale"]
+    .doc("Time constant in flux limitation factor variation [seconds]. < 0 is off.")
+    .withDefault(-1.0) / seconds;
+
+  particle_flux_limiter = options["particle_flux_limiter"]
+    .doc("Enable particle flux limiter?")
+    .withDefault(true);
+
+  heat_flux_limiter = options["heat_flux_limiter"]
+    .doc("Enable heat flux limiter?")
+    .withDefault(true);
+
+  momentum_flux_limiter = options["momentum_flux_limiter"]
+    .doc("Enable momentum flux limiter?")
+    .withDefault(true);
+
+  flux_limit_alpha = options["flux_limit_alpha"]
+    .doc("Scale flux limits")
+    .withDefault(1.0);
+
+  flux_limit_gamma = options["flux_limit_gamma"]
+    .doc("Higher values increase sharpness of flux limiting")
+    .withDefault(2.0);
 
   neutral_viscosity = options["neutral_viscosity"]
     .doc("Include neutral gas viscosity?")
     .withDefault<bool>(true);
+
+  maximum_mfp = options["maximum_mfp"]
+    .doc("Optional maximum mean free path in [m] for diffusive processes. < 0 is off")
+    .withDefault(0.1);
 
   if (precondition) {
     inv = std::unique_ptr<Laplacian>(Laplacian::create(&options["precon_laplace"]));
@@ -156,6 +179,8 @@ void NeutralMixed::transform(Options& state) {
   Pnlim = floor(Nnlim * Tn, 1e-8);
   Pnlim.applyBoundary();
 
+  Tnlim = Pnlim / Nnlim;
+
   /////////////////////////////////////////////////////
   // Parallel boundary conditions
   TRACE("Neutral boundary conditions");
@@ -249,33 +274,20 @@ void NeutralMixed::finally(const Options& state) {
   // Calculate cross-field diffusion from collision frequency
   //
   //
-  BoutReal neutral_lmax =
-      0.1 / get<BoutReal>(state["units"]["meters"]); // Normalised length
-
-  Field3D Rnn = sqrt(Tn / AA) / neutral_lmax; // Neutral-neutral collisions [normalised frequency]
-
   if (localstate.isSet("collision_frequency")) {
     // Dnn = Vth^2 / sigma
-    Dnn = (Tn / AA) / (get<Field3D>(localstate["collision_frequency"]) + Rnn);
-  } else {
+
+    if (maximum_mfp > 0) {   // MFP limit enabled
+        Field3D Rnn = sqrt(Tn / AA) / (maximum_mfp / get<BoutReal>(state["units"]["meters"]));
+        Dnn = (Tn / AA) / (get<Field3D>(localstate["collision_frequency"]) + Rnn);
+      } else {   // MFP limit disabled
+        Dnn = (Tn / AA) / (get<Field3D>(localstate["collision_frequency"]));
+      }
+      
+  } else {  // If no collisions, hardcode max MFP to 0.1m
+    output_warn.write("No collisions set for the neutrals, limiting mean free path to 0.1m");
+    Field3D Rnn = sqrt(Tn / AA) / (0.1 / get<BoutReal>(state["units"]["meters"]));
     Dnn = (Tn / AA) / Rnn;
-  }
-
-  if (flux_limit > 0.0) {
-    // Apply flux limit to diffusion,
-    // using the local thermal speed and pressure gradient magnitude
-    Field3D Dmax = flux_limit * sqrt(Tn / AA) /
-      (abs(Grad(logPnlim)) + 1. / neutral_lmax);
-    BOUT_FOR(i, Dmax.getRegion("RGN_NOBNDRY")) {
-      Dnn[i] = BOUTMIN(Dnn[i], Dmax[i]);
-    }
-  }
-
-  if (diffusion_limit > 0.0) {
-    // Impose an upper limit on the diffusion coefficient
-    BOUT_FOR(i, Dnn.getRegion("RGN_NOBNDRY")) {
-      Dnn[i] = BOUTMIN(Dnn[i], diffusion_limit);
-    }
   }
 
   mesh->communicate(Dnn);
@@ -312,15 +324,132 @@ void NeutralMixed::finally(const Options& state) {
     }
   }
 
+  // Heat conductivity
+  // Note: This is kappa_n = (5/2) * Pn / (m * nu)
+  //       where nu is the collision frequency used in Dnn
+  kappa_n = (5. / 2) * DnnNn;
+
+  // Viscosity
+  eta_n = AA * (2. / 5) * kappa_n;
+
   // Sound speed appearing in Lax flux for advection terms
   Field3D sound_speed = sqrt(Tn * (5. / 3) / AA);
+
+  // Set factors that multiply the fluxes
+  particle_flux_factor = 1.0;
+  momentum_flux_factor = 1.0;
+  heat_flux_factor = 1.0;
+  if (flux_limit) {
+    // Apply flux limiters
+    // Note: Fluxes calculated here are cell centre, rather than cell edge
+
+    // Cross-field velocity
+    Vector3D v_perp = -Dnn * Grad_perp(logPnlim);
+
+    // Total velocity, perpendicular + parallel
+    Vector3D v_total = v_perp;
+    ASSERT2(v_total.covariant == true);
+    auto* coord = mesh->getCoordinates();
+    v_total.y = Vn * (coord->J * coord->Bxy); // Set parallel component
+
+    Field3D v_sq = v_perp * v_perp + SQ(Vn); // v dot v
+    Field3D v_abs = sqrt(v_sq); // |v|
+
+    // Magnitude of the particle flux
+    Field3D particle_flux_abs = Nnlim * v_abs;
+
+    // Normalised particle flux limit
+    Field3D particle_limit = Nnlim * 0.25 * sqrt(8 * Tnlim / (PI * AA));
+
+    // Particle flux reduction factor
+    if (particle_flux_limiter){
+      particle_flux_factor = pow(1. + pow(particle_flux_abs / (flux_limit_alpha * particle_limit),
+                                          flux_limit_gamma),
+                                -1./flux_limit_gamma);
+    } else {
+      particle_flux_factor = 1.0;
+    }
+
+    // Flux of parallel momentum
+    // Note: Flux-limited particle flux is used in calculating the momentum flux before the
+    //       momentum limiter is applied.
+    //
+    // The resulting momentum_flux_factor is applied to the momentum advection and viscosity terms,
+    // and so also scales the advection of kinetic energy
+    Vector3D momentum_flux = particle_flux_factor * NVn * v_total;
+    if (neutral_viscosity) {
+      momentum_flux -= eta_n * Grad_perp(Vn);
+    }
+    Field3D momentum_flux_abs = sqrt(momentum_flux * momentum_flux);
+    Field3D momentum_limit = Pnlim;
+
+    if (momentum_flux_limiter) {
+      momentum_flux_factor = pow(1. + pow(momentum_flux_abs / (flux_limit_alpha * momentum_limit),
+                                          flux_limit_gamma),
+                                -1./flux_limit_gamma);
+    } else {
+      momentum_flux_factor = 1.0;
+    }
+    // Flux of heat
+    // Note:
+    //  - Limiting the heat flux, not energy flux
+    //  - Advection and heat conduction are both vectors, and e.g
+    //    could be in opposite directions.
+    //  - Flux doesn't include compression term, or kinetic energy transport
+    //    that is in the momentum equation
+    Vector3D heat_flux = (3./2) * Pn * particle_flux_factor * v_total + Pn * particle_flux_factor * v_perp - kappa_n * Grad(Tn);
+
+    Field3D heat_flux_abs = sqrt(heat_flux * heat_flux);
+    Field3D heat_limit = Pnlim * sqrt(2. * Tnlim / (PI * AA));
+
+    if (heat_flux_limiter) {
+      heat_flux_factor = pow(1. + pow(heat_flux_abs / (flux_limit_alpha * heat_limit),
+                                      flux_limit_gamma),
+                              -1./flux_limit_gamma);
+    } else {
+      heat_flux_factor = 1.0;
+    }
+    // Communicate guard cells and apply boundary conditions
+    // because the flux factors will be differentiated
+    mesh->communicate(particle_flux_factor, momentum_flux_factor, heat_flux_factor);
+    particle_flux_factor.applyBoundary("neumann");
+    momentum_flux_factor.applyBoundary("neumann");
+    heat_flux_factor.applyBoundary("neumann");
+
+    if (flux_factor_timescale > 0) {
+      // Smooth flux limitation factors over time
+      // Suppress rapid changes in flux limitation factors, while retaining
+      // the same steady-state solution.
+      BoutReal time = get<BoutReal>(state["time"]);
+      if (flux_factor_time < 0.0) {
+        // First time, so just copy values
+        particle_flux_avg = particle_flux_factor;
+        momentum_flux_avg = momentum_flux_factor;
+        heat_flux_avg = heat_flux_factor;
+      } else {
+        // Weight by a factor that depends on the elapsed time.
+        BoutReal weight = exp(-(time - flux_factor_time) / flux_factor_timescale);
+
+        particle_flux_avg = weight * particle_flux_avg + (1. - weight) * particle_flux_factor;
+        momentum_flux_avg = weight * momentum_flux_avg + (1. - weight) * momentum_flux_factor;
+        heat_flux_avg = weight * heat_flux_avg + (1. - weight) * heat_flux_factor;
+
+        particle_flux_factor = particle_flux_avg;
+        momentum_flux_factor = momentum_flux_avg;
+        heat_flux_factor = heat_flux_avg;
+      }
+      flux_factor_time = time;
+    }
+  }
 
   /////////////////////////////////////////////////////
   // Neutral density
   TRACE("Neutral density");
-  ddt(Nn) = -FV::Div_par_mod<hermes::Limiter>(Nn, Vn, sound_speed) // Advection
-            + FV::Div_a_Grad_perp(DnnNn, logPnlim) // Perpendicular diffusion
-      ;
+
+  // Note: Parallel and perpendicular flux scaled by limiter
+  ddt(Nn) = -FV::Div_par_mod<hermes::Limiter>(Nn * particle_flux_factor, Vn, sound_speed) // Advection
+    + FV::Div_a_Grad_perp(DnnNn * particle_flux_factor, logPnlim) // Perpendicular diffusion
+    ;
 
   Sn = density_source; // Save for possible output
   if (localstate.isSet("density_source")) {
@@ -333,26 +462,11 @@ void NeutralMixed::finally(const Options& state) {
   TRACE("Neutral momentum");
 
   ddt(NVn) =
-      -AA * FV::Div_par_fvv<hermes::Limiter>(Nnlim, Vn, sound_speed) // Momentum flow
-      - Grad_par(Pn)                                                 // Pressure gradient
-      + FV::Div_a_Grad_perp(DnnNVn, logPnlim) // Perpendicular diffusion
-      ;
-
-  if (neutral_viscosity) {
-    // NOTE: The following viscosity terms are are not (yet) balanced
-    //       by a viscous heating term
-
-    // Relationship between heat conduction and viscosity for neutral
-    // gas Chapman, Cowling "The Mathematical Theory of Non-Uniform
-    // Gases", CUP 1952 Ferziger, Kaper "Mathematical Theory of
-    // Transport Processes in Gases", 1972
-    // eta_n = (2. / 5) * kappa_n;
-    //
-
-    ddt(NVn) += AA * FV::Div_a_Grad_perp((2. / 5) * DnnNn, Vn)    // Perpendicular viscosity
-              + AA * FV::Div_par_K_Grad_par((2. / 5) * DnnNn, Vn) // Parallel viscosity
-      ;
-  }
+    // Note: The second argument (Vn) is squared in this operator, so the limiters are applied to the first argument
+    -AA * FV::Div_par_fvv<hermes::Limiter>(Nnlim * particle_flux_factor * momentum_flux_factor, Vn, sound_speed) // Momentum flow
+    - Grad_par(Pn)                                                 // Pressure gradient. Not included in flux limit.
+    + FV::Div_a_Grad_perp(DnnNVn * particle_flux_factor * momentum_flux_factor, logPnlim) // Perpendicular diffusion
+    ;
 
   if (localstate.isSet("momentum_source")) {
     Snv = get<Field3D>(localstate["momentum_source"]);
@@ -363,11 +477,11 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral pressure
   TRACE("Neutral pressure");
 
-  ddt(Pn) = -FV::Div_par_mod<hermes::Limiter>(Pn, Vn, sound_speed) // Advection
-            - (2. / 3) * Pn * Div_par(Vn)                          // Compression
-            + FV::Div_a_Grad_perp(DnnPn, logPnlim) // Perpendicular diffusion
-            + FV::Div_a_Grad_perp(DnnNn, Tn)       // Conduction
-            + FV::Div_par_K_Grad_par(DnnNn, Tn)    // Parallel conduction
+  ddt(Pn) = -FV::Div_par_mod<hermes::Limiter>(Pn * particle_flux_factor * heat_flux_factor, Vn, sound_speed) // Advection
+    - (2. / 3) * Pn * Div_par(Vn)                       // Compression
+    + FV::Div_a_Grad_perp((5. / 3) * DnnPn * particle_flux_factor * heat_flux_factor, logPnlim)   // Perpendicular advection: q = 5/2 p u_perp
+    + (2. / 3) * (FV::Div_a_Grad_perp(kappa_n * heat_flux_factor, Tn)      // Perpendicular Conduction
+                + FV::Div_par_K_Grad_par(kappa_n * heat_flux_factor, Tn))  // Parallel conduction
       ;
 
   Sp = pressure_source;
@@ -375,6 +489,15 @@ void NeutralMixed::finally(const Options& state) {
     Sp += (2. / 3) * get<Field3D>(localstate["energy_source"]);
   }
   ddt(Pn) += Sp;
+
+  if (neutral_viscosity) {
+    Field3D momentum_source = FV::Div_a_Grad_perp(eta_n * momentum_flux_factor, Vn)    // Perpendicular viscosity
+              + FV::Div_par_K_Grad_par(eta_n * momentum_flux_factor, Vn) // Parallel viscosity
+      ;
+
+    ddt(NVn) += momentum_source; // Viscosity
+    ddt(Pn) -= (2. / 3) * Vn * momentum_source; // Viscous heating
+  }
 
   BOUT_FOR(i, Pn.getRegion("RGN_ALL")) {
     if ((Pn[i] < 1e-9) && (ddt(Pn)[i] < 0.0)) {
@@ -414,6 +537,7 @@ void NeutralMixed::outputVars(Options& state) {
   auto Tnorm = get<BoutReal>(state["Tnorm"]);
   auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
   auto Cs0 = get<BoutReal>(state["Cs0"]);
+  auto rho_s0 = get<BoutReal>(state["rho_s0"]);
   const BoutReal Pnorm = SI::qe * Tnorm * Nnorm;
 
   state[std::string("N") + name].setAttributes({{"time_dimension", "t"},
@@ -468,6 +592,7 @@ void NeutralMixed::outputVars(Options& state) {
                     {"standard_name", "temperature"},
                     {"long_name", name + " temperature"},
                     {"source", "neutral_mixed"}});
+
     set_with_attrs(state[std::string("Dnn") + name], Dnn,
                    {{"time_dimension", "t"},
                     {"units", "m^2/s"},
@@ -475,6 +600,21 @@ void NeutralMixed::outputVars(Options& state) {
                     {"standard_name", "diffusion coefficient"},
                     {"long_name", name + " diffusion coefficient"},
                     {"source", "neutral_mixed"}});
+    set_with_attrs(state[std::string("eta_") + name], eta_n,
+                   {{"time_dimension", "t"},
+                    {"units", "Pa s"},
+                    {"conversion", SQ(rho_s0) * Omega_ci * SI::Mp * Nnorm},
+                    {"standard_name", "viscosity"},
+                    {"long_name", name + " viscosity"},
+                    {"source", "neutral_mixed"}});
+    set_with_attrs(state[std::string("kappa_") + name], kappa_n,
+                   {{"time_dimension", "t"},
+                    {"units", "W / m / eV"},
+                    {"conversion", SI::qe * Nnorm * rho_s0 * Cs0},
+                    {"standard_name", "heat conductivity"},
+                    {"long_name", name + " heat conductivity"},
+                    {"source", "neutral_mixed"}});
+
     set_with_attrs(state[std::string("SN") + name], Sn,
                    {{"time_dimension", "t"},
                     {"units", "m^-3 s^-1"},
@@ -513,6 +653,30 @@ void NeutralMixed::outputVars(Options& state) {
                     {"species", name},
                     {"source", "neutral_mixed"}});
 
+    set_with_attrs(state[std::string("particle_flux_factor_") + name], particle_flux_factor,
+                   {{"time_dimension", "t"},
+                    {"units", ""},
+                    {"conversion", 1.0},
+                    {"standard_name", "flux factor"},
+                    {"long_name", name + " particle flux factor"},
+                    {"species", name},
+                    {"source", "neutral_mixed"}});
+    set_with_attrs(state[std::string("momentum_flux_factor_") + name], momentum_flux_factor,
+                   {{"time_dimension", "t"},
+                    {"units", ""},
+                    {"conversion", 1.0},
+                    {"standard_name", "flux factor"},
+                    {"long_name", name + " momentum flux factor"},
+                    {"species", name},
+                    {"source", "neutral_mixed"}});
+    set_with_attrs(state[std::string("heat_flux_factor_") + name], heat_flux_factor,
+                   {{"time_dimension", "t"},
+                    {"units", ""},
+                    {"conversion", 1.0},
+                    {"standard_name", "flux factor"},
+                    {"long_name", name + " heat flux factor"},
+                    {"species", name},
+                    {"source", "neutral_mixed"}});
   }
 }
 
@@ -524,7 +688,7 @@ void NeutralMixed::precon(const Options& state, BoutReal gamma) {
   // Neutral gas diffusion
   // Solve (1 - gamma*Dnn*Delp2)^{-1}
 
-  Field3D coef = -gamma * Dnn;
+  Field3D coef = -gamma * Dnn * particle_flux_factor;
 
   if (state.isSet("scale_timederivs")) {
     coef *= get<Field3D>(state["scale_timederivs"]);

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -3,6 +3,7 @@
 
 #include <bout/utils.hxx> // for trim, strsplit
 #include "../include/hermes_utils.hxx"  // For indexAt
+#include "../include/hermes_utils.hxx"  // For indexAt
 #include <bout/coordinates.hxx>
 #include <bout/mesh.hxx>
 #include <bout/constants.hxx>
@@ -22,13 +23,13 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
                                    .as<std::string>(),
                                ',');
 
-
+  
   // Neutral pump
   // Mark cells as having a pump by setting the Field2D is_pump to 1 in the grid file
   // Works only on SOL and PFR edges, where it locally modifies the recycle multiplier to the pump albedo
   is_pump = 0.0;
   mesh->get(is_pump, std::string("is_pump"));
-
+      
   for (const auto& species : species_list) {
     std::string from = trim(species, " \t\r()"); // The species name in the list
 
@@ -63,7 +64,6 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
       from_options["pump_recycle_multiplier"]
           .doc("Multiply the pump boundary recycling flux by this factor (like albedo). Should be >=0 and <= 1")
           .withDefault<BoutReal>(1.0);
-    
 
     BoutReal target_recycle_energy = from_options["target_recycle_energy"]
                                   .doc("Fixed energy of the recycled particles at target [eV]")
@@ -80,6 +80,36 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
                                   .withDefault<BoutReal>(3.0)
                               / Tnorm; // Normalise from eV
 
+    BoutReal target_fast_recycle_fraction =
+        from_options["target_fast_recycle_fraction"]
+            .doc("Fraction of ions undergoing fast reflection at target")
+            .withDefault<BoutReal>(0);
+
+    BoutReal pfr_fast_recycle_fraction =
+        from_options["pfr_fast_recycle_fraction"]
+            .doc("Fraction of ions undergoing fast reflection at pfr")
+            .withDefault<BoutReal>(0);
+
+    BoutReal sol_fast_recycle_fraction =
+        from_options["sol_fast_recycle_fraction"]
+            .doc("Fraction of ions undergoing fast reflection at sol")
+            .withDefault<BoutReal>(0);
+
+    BoutReal target_fast_recycle_energy_factor =
+        from_options["target_fast_recycle_energy_factor"]
+            .doc("Fraction of energy retained by fast recycled neutrals at target")
+            .withDefault<BoutReal>(0);
+
+    BoutReal sol_fast_recycle_energy_factor =
+        from_options["sol_fast_recycle_energy_factor"]
+            .doc("Fraction of energy retained by fast recycled neutrals at sol")
+            .withDefault<BoutReal>(0);
+
+    BoutReal pfr_fast_recycle_energy_factor =
+        from_options["pfr_fast_recycle_energy_factor"]
+            .doc("Fraction of energy retained by fast recycled neutrals at pfr")
+            .withDefault<BoutReal>(0);
+
     if ((target_recycle_multiplier < 0.0) or (target_recycle_multiplier > 1.0)
     or (sol_recycle_multiplier < 0.0) or (sol_recycle_multiplier > 1.0)
     or (pfr_recycle_multiplier < 0.0) or (pfr_recycle_multiplier > 1.0)
@@ -91,7 +121,9 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
     channels.push_back({
       from, to, 
       target_recycle_multiplier, sol_recycle_multiplier, pfr_recycle_multiplier, pump_recycle_multiplier,
-      target_recycle_energy, sol_recycle_energy, pfr_recycle_energy});
+      target_recycle_energy, sol_recycle_energy, pfr_recycle_energy,
+      target_fast_recycle_fraction, pfr_fast_recycle_fraction, sol_fast_recycle_fraction,
+      target_fast_recycle_energy_factor, sol_fast_recycle_energy_factor, pfr_fast_recycle_energy_factor});
 
     // Boolean flags for enabling recycling in different regions
     target_recycle = from_options["target_recycle"]
@@ -108,7 +140,7 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
 
     neutral_pump = from_options["neutral_pump"]
                    .doc("Neutral pump enabled? Note, need location in grid file")
-                   .withDefault<bool>(false);
+                   .withDefault<bool>(false);                 
   }
 }
 
@@ -129,9 +161,9 @@ void Recycling::transform(Options& state) {
 
     const Field3D N = get<Field3D>(species_from["density"]);
     const Field3D V = get<Field3D>(species_from["velocity"]); // Parallel flow velocity
+    const Field3D T = get<Field3D>(species_from["temperature"]); // Ion temperature
 
     Options& species_to = state["species"][channel.to];
-
     const Field3D Nn = get<Field3D>(species_to["density"]);
     const Field3D Pn = get<Field3D>(species_to["pressure"]);
     const Field3D Tn = get<Field3D>(species_to["temperature"]);
@@ -146,8 +178,19 @@ void Recycling::transform(Options& state) {
                                 ? getNonFinal<Field3D>(species_to["energy_source"])
                                 : 0.0;
 
+
     // Recycling at the divertor target plates
     if (target_recycle) {
+
+      // Fast recycling needs to know how much energy the "from" species is losing to the boundary
+      if (species_from.isSet("energy_flow_ylow")) {
+        energy_flow_ylow = get<Field3D>(species_from["energy_flow_ylow"]);
+      } else {
+        energy_flow_ylow = 0;
+        if (channel.target_fast_recycle_fraction > 0) {
+          throw BoutException("Target fast recycle enabled but no sheath heat flow available in energy_flow_ylow! \nCurrently only sheath_boundary_simple is supported for fast recycling.");
+        }
+      }
 
       target_recycle_density_source = 0;
       target_recycle_energy_source = 0;
@@ -166,23 +209,30 @@ void Recycling::transform(Options& state) {
             flux = 0.0;
           }
 
-          // Flow of recycled species inwards
+          // Flow of recycled neutrals into domain [s-1]
           BoutReal flow =
               channel.target_multiplier * flux
-              * (J(r.ind, mesh->ystart) + J(r.ind, mesh->ystart - 1))
-              / (sqrt(g_22(r.ind, mesh->ystart)) + sqrt(g_22(r.ind, mesh->ystart - 1)));
+              * (J(r.ind, mesh->ystart) + J(r.ind, mesh->ystart - 1)) / (sqrt(g_22(r.ind, mesh->ystart)) + sqrt(g_22(r.ind, mesh->ystart - 1)))
+              * 0.5*(dx(r.ind, mesh->ystart) + dx(r.ind, mesh->ystart - 1)) * 0.5*(dz(r.ind, mesh->ystart) + dz(r.ind, mesh->ystart - 1));  
 
-          // Add to density source
-          target_recycle_density_source(r.ind, mesh->ystart, jz) += flow 
-              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
-          density_source(r.ind, mesh->ystart, jz) += flow 
-              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
+          BoutReal volume  = J(r.ind, mesh->ystart) * dx(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart) * dz(r.ind, mesh->ystart);
 
-          // energy of recycled particles
-          target_recycle_energy_source(r.ind, mesh->ystart, jz) += channel.target_energy * flow 
-              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
-          energy_source(r.ind, mesh->ystart, jz) += channel.target_energy * flow 
-              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
+          // Calculate sources in the final cell [m^-3 s^-1]
+          target_recycle_density_source(r.ind, mesh->ystart, jz) += flow / volume;    // For diagnostic 
+          density_source(r.ind, mesh->ystart, jz) += flow / volume;         // For use in solver
+
+          // Energy of recycled particles
+          BoutReal ion_energy_flow = energy_flow_ylow(r.ind, mesh->ystart, jz) * -1;   // This is ylow end so take first domain cell and flip sign
+
+          // Blend fast (ion energy) and thermal (constant energy) recycling 
+          // Calculate returning neutral heat flow in [W]
+          BoutReal recycle_energy_flow = 
+            ion_energy_flow * channel.target_multiplier * channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction   // Fast recycling part
+            + flow * (1 - channel.target_fast_recycle_fraction) * channel.target_energy;   // Thermal recycling part
+
+          // Divide heat flow in [W] by cell volume to get source in [m^-3 s^-1]
+          target_recycle_energy_source(r.ind, mesh->ystart, jz) += recycle_energy_flow / volume;
+          energy_source(r.ind, mesh->ystart, jz) += recycle_energy_flow / volume;
         }
       }
 
@@ -201,37 +251,64 @@ void Recycling::transform(Options& state) {
             flux = 0.0;
           }
 
-          // Flow of neutrals inwards
+          // Flow of recycled neutrals into domain [s-1]
           BoutReal flow =
-              channel.target_multiplier * flux * (J(r.ind, mesh->yend) + J(r.ind, mesh->yend + 1))
-              / (sqrt(g_22(r.ind, mesh->yend)) + sqrt(g_22(r.ind, mesh->yend + 1)));
+              channel.target_multiplier * flux 
+              * (J(r.ind, mesh->yend) + J(r.ind, mesh->yend + 1)) / (sqrt(g_22(r.ind, mesh->yend)) + sqrt(g_22(r.ind, mesh->yend + 1)))
+              * 0.5*(dx(r.ind, mesh->yend) + dx(r.ind, mesh->yend + 1)) * 0.5*(dz(r.ind, mesh->yend) + dz(r.ind, mesh->yend + 1)); 
 
-          // Rate of change of neutrals in final cell
-          // Add to density source
-          target_recycle_density_source(r.ind, mesh->yend, jz) += flow 
-              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
-          density_source(r.ind, mesh->yend, jz) += flow 
-              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
+          BoutReal volume  = J(r.ind, mesh->yend) * dx(r.ind, mesh->yend) * dy(r.ind, mesh->yend) * dz(r.ind, mesh->yend);
 
-          target_recycle_energy_source(r.ind, mesh->yend, jz) += channel.target_energy * flow 
-              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
-          energy_source(r.ind, mesh->yend, jz) += channel.target_energy * flow 
-              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
+          // Calculate sources in the final cell [m^-3 s^-1]
+          target_recycle_density_source(r.ind, mesh->yend, jz) += flow / volume;    // For diagnostic 
+          density_source(r.ind, mesh->yend, jz) += flow / volume;         // For use in solver
+
+          // Energy of recycled particles
+          BoutReal ion_energy_flow = energy_flow_ylow(r.ind, mesh->yend + 1, jz);   // Ion heat flow to wall in [W]. This is yup end so take guard cell
+
+          // Blend fast (ion energy) and thermal (constant energy) recycling 
+          // Calculate returning neutral heat flow in [W]
+          BoutReal recycle_energy_flow = 
+            ion_energy_flow * channel.target_multiplier * channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction   // Fast recycling part
+            + flow * (1 - channel.target_fast_recycle_fraction) * channel.target_energy;   // Thermal recycling part
+
+
+          // Divide heat flow in [W] by cell volume to get source in [m^-3 s^-1]
+          target_recycle_energy_source(r.ind, mesh->yend, jz) += recycle_energy_flow / volume;
+          energy_source(r.ind, mesh->yend, jz) += recycle_energy_flow / volume;
         }
       }
     }
 
     // Initialise counters of pump recycling fluxes
-    pump_recycle_density_source = 0;
-    pump_recycle_energy_source = 0;
     wall_recycle_density_source = 0;
     wall_recycle_energy_source = 0;
+    pump_density_source = 0;
+    pump_energy_source = 0;
+
+    // Get edge particle and heat for the species being recycled
+    if (sol_recycle or pfr_recycle) {
+
+      if (species_from.isSet("energy_flow_xlow")) {
+        energy_flow_xlow = get<Field3D>(species_from["energy_flow_xlow"]);
+      } else if ((channel.sol_fast_recycle_fraction > 0) or (channel.pfr_fast_recycle_fraction > 0)) {
+        throw BoutException("SOL/PFR fast recycle enabled but no cell edge heat flow available, check your wall BC choice");
+      };
+
+      if (species_from.isSet("particle_flow_xlow")) {
+        particle_flow_xlow = get<Field3D>(species_from["particle_flow_xlow"]);
+      } else if ((channel.sol_fast_recycle_fraction > 0) or (channel.pfr_fast_recycle_fraction > 0)) {
+        throw BoutException("SOL/PFR fast recycle enabled but no cell edge particle flow available, check your wall BC choice");
+      };
+      
+    }
 
     // Recycling at the SOL edge (2D/3D only)
     if (sol_recycle) {
 
       // Flow out of domain is positive in the positive coordinate direction
-      radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]);
+      Field3D radial_particle_outflow = particle_flow_xlow;
+      Field3D radial_energy_outflow = energy_flow_xlow;
 
       if(mesh->lastX()){  // Only do this for the processor which has the edge region
         for(int iy=0; iy < mesh->LocalNy ; iy++){
@@ -242,12 +319,12 @@ void Recycling::transform(Options& state) {
                  * dy(mesh->xend, iy) * dz(mesh->xend, iy);
 
             // If cell is a pump, overwrite multiplier with pump multiplier
-            BoutReal multiplier = channel.pfr_multiplier;
+            BoutReal multiplier = channel.sol_multiplier;
             if ((is_pump(mesh->xend, iy) == 1.0) and (neutral_pump)) {
               multiplier = channel.pump_multiplier;
             }
 
-            // Flow of recycled species back from the edge
+            // Flow of recycled species back from the edge due to recycling
             // SOL edge = LHS flow of inner guard cells on the high X side (mesh->xend+1)
             // Recycling source is 0 for each cell where the flow goes into instead of out of the domain
             BoutReal recycle_particle_flow = 0;
@@ -255,14 +332,19 @@ void Recycling::transform(Options& state) {
               recycle_particle_flow = multiplier * radial_particle_outflow(mesh->xend+1, iy, iz); 
             } 
 
-            // Divide by volume to get source
-            BoutReal recycle_source = recycle_particle_flow / volume;
+            BoutReal ion_energy_flow = radial_energy_outflow(mesh->xend+1, iy, iz);   // Ion heat flow to wall in [W]. This is on xlow edge so take guard cell
 
-            // Pump source terms
-            BoutReal esink = 0;
-            BoutReal psink = 0;
+            // Blend fast (ion energy) and thermal (constant energy) recycling 
+            // Calculate returning neutral heat flow in [W]
+            BoutReal recycle_energy_flow = 
+              ion_energy_flow * channel.sol_multiplier * channel.sol_fast_recycle_energy_factor * channel.sol_fast_recycle_fraction   // Fast recycling part
+              + recycle_particle_flow * (1 - channel.sol_fast_recycle_fraction) * channel.sol_energy;   // Thermal recycling part
 
-            // Compute the neutral loss sink and combine with the recycled source to compute overall neutral sources
+            // Calculate neutral pump neutral sinks due to neutral impingement
+            // These are additional to particle sinks due to recycling
+            BoutReal pump_neutral_energy_sink = 0;
+            BoutReal pump_neutral_particle_sink = 0;
+
             if ((is_pump(mesh->xend, iy) == 1.0) and (neutral_pump)) {
 
               auto i = indexAt(Nn, mesh->xend, iy, iz);   // Final domain cell
@@ -293,32 +375,29 @@ void Recycling::transform(Options& state) {
 
               // Calculate particle and energy fluxes of neutrals hitting the pump
               // Assume thermal velocity greater than perpendicular velocity and use it for flux calc
-              BoutReal pflow = v_th * nnsheath * dasheath;   // [s^-1]
-              psink = pflow / dv * (1 - multiplier);   // Particle sink [s^-1 m^-3]
+              BoutReal pump_neutral_particle_flow = v_th * nnsheath * dasheath;   // [s^-1]
+              pump_neutral_particle_sink = pump_neutral_particle_flow / dv * (1 - multiplier);   // Particle sink [s^-1 m^-3]
 
               // Use gamma=2.0 as per Stangeby p.69, total energy of static Maxwellian
-              BoutReal eflow = 2.0 * tnsheath * v_th * nnsheath * dasheath;   // [W]
-              esink = eflow / dv * (1 - multiplier);   // heatsink [W m^-3]
+              BoutReal pump_neutral_energy_flow = 2.0 * tnsheath * v_th * nnsheath * dasheath;   // [W]
+              pump_neutral_energy_sink = pump_neutral_energy_flow / dv * (1 - multiplier);   // heatsink [W m^-3]
 
-              // Pump puts neutral particle and energy source in final domain cell
-              // Source accounts for recycled ions and the particle sink due to neutrals hitting the pump
-              // Note that the ions are explicitly transported out of the domain by anomalous_diffusion.cxx
-              // the pump picks this up and adds a recycling source based on this, but doesn't need an ion sink.
-              // Neutrals are not explicitly transported out by any component and must be taken out by the sink below.
-              // Pump multiplier controls both fraction of recycled ions and fraction of returned neutrals 
-              pump_recycle_density_source(mesh->xend, iy, iz) += recycle_source - psink;
-              pump_recycle_energy_source(mesh->xend, iy, iz) += recycle_source * channel.sol_energy - esink;
+              // Divide flows by volume to get sources
+              // Save to pump diagnostic
+              pump_density_source(mesh->xend, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
+              pump_energy_source(mesh->xend, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink;  
+
 
             } else {
-              wall_recycle_density_source(mesh->xend, iy, iz) += recycle_source;
-              wall_recycle_energy_source(mesh->xend, iy, iz) += recycle_source * channel.sol_energy;
+            // Save to wall diagnostic (pump sinks are 0 if not on pump)
+            wall_recycle_density_source(mesh->xend, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
+            wall_recycle_energy_source(mesh->xend, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink; 
             }
 
-            // Add to density source which will be picked up by evolve_density.cxx
-            // Add to energy source which will be picked up by evolve_pressure.cxx
-            // psink and esink are additional sinks from the neutral pump which are 0 if disabled
-            density_source(mesh->xend, iy, iz) += recycle_source - psink;
-            energy_source(mesh->xend, iy, iz) += recycle_source * channel.pfr_energy - esink;
+            // Save to solver
+            density_source(mesh->xend, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
+            energy_source(mesh->xend, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink; 
+
 
           }
         }
@@ -329,25 +408,25 @@ void Recycling::transform(Options& state) {
     if (pfr_recycle) {
 
       // PFR is flipped compared to edge: x=0 is at the PFR edge. Therefore outflow is in the negative coordinate direction.
-      radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]) * -1;
+      Field3D radial_particle_outflow = particle_flow_xlow * -1;
+      Field3D radial_energy_outflow = energy_flow_xlow * -1;
 
       if(mesh->firstX()){   // Only do this for the processor which has the core region
         if (!mesh->periodicY(mesh->xstart)) {   // Only do this for the processor with a periodic Y, i.e. the PFR
           for(int iy=0; iy < mesh->LocalNy ; iy++){
             for(int iz=0; iz < mesh->LocalNz; iz++){
             
-
               // Volume of cell adjacent to wall which will receive source
               BoutReal volume = J(mesh->xstart, iy) * dx(mesh->xstart, iy)
                   * dy(mesh->xstart, iy) * dz(mesh->xstart, iy);
 
               // If cell is a pump, overwrite multiplier with pump multiplier
               BoutReal multiplier = channel.pfr_multiplier;
-              if ((is_pump(mesh->xstart, iy, iz) == 1.0) and (neutral_pump))  {
+              if ((is_pump(mesh->xstart, iy) == 1.0) and (neutral_pump)) {
                 multiplier = channel.pump_multiplier;
               }
-              
-              // Flow of recycled species back from the edge
+
+              // Flow of recycled species back from the edge due to recycling
               // PFR edge = LHS flow of the first domain cell on the low X side (mesh->xstart)
               // Recycling source is 0 for each cell where the flow goes into instead of out of the domain
               BoutReal recycle_particle_flow = 0;
@@ -355,15 +434,22 @@ void Recycling::transform(Options& state) {
                 recycle_particle_flow = multiplier * radial_particle_outflow(mesh->xstart, iy, iz); 
               }
 
-              // Divide by volume to get source
-              BoutReal recycle_source = recycle_particle_flow / volume;
+              BoutReal ion_energy_flow = radial_energy_outflow(mesh->xstart, iy, iz);   // Ion heat flow to wall in [W]. This is on xlow edge so take first domain cell
 
-              // Pump source terms
-              BoutReal esink = 0;
-              BoutReal psink = 0;
+              // Blend fast (ion energy) and thermal (constant energy) recycling 
+              // Calculate returning neutral heat flow in [W]
+              BoutReal recycle_energy_flow = 
+                ion_energy_flow * channel.pfr_multiplier * channel.pfr_fast_recycle_energy_factor * channel.pfr_fast_recycle_fraction   // Fast recycling part
+                + recycle_particle_flow * (1 - channel.pfr_fast_recycle_fraction) * channel.pfr_energy;   // Thermal recycling part
+
+              // Calculate neutral pump neutral sinks due to neutral impingement
+              // These are additional to particle sinks due to recycling
+              BoutReal pump_neutral_energy_sink = 0;
+              BoutReal pump_neutral_particle_sink = 0;
 
               // Add to appropriate diagnostic field depending if pump or not
               if ((is_pump(mesh->xstart, iy) == 1.0) and (neutral_pump))  {
+
                 auto i = indexAt(Nn, mesh->xstart, iy, iz);   // Final domain cell
                 auto is = i.xp();   // Second to final domain cell
                 auto ig = i.xm();   // First guard cell
@@ -392,36 +478,35 @@ void Recycling::transform(Options& state) {
 
                 // Calculate particle and energy fluxes of neutrals hitting the pump
                 // Assume thermal velocity greater than perpendicular velocity and use it for flux calc
-                BoutReal pflow = v_th * nnsheath * dasheath;   // [s^-1]
-                psink = pflow / dv * (1 - multiplier);   // Particle sink [s^-1 m^-3]
+                BoutReal pump_neutral_particle_flow = v_th * nnsheath * dasheath;   // [s^-1]
+                pump_neutral_particle_sink = pump_neutral_particle_flow / dv * (1 - multiplier);   // Particle sink [s^-1 m^-3]
 
                 // Use gamma=2.0 as per Stangeby p.69, total energy of static Maxwellian
-                BoutReal eflow = 2.0 * tnsheath * v_th * nnsheath * dasheath;   // [W]
-                esink = eflow / dv * (1 - multiplier);   // heatsink [W m^-3]
+                BoutReal pump_neutral_energy_flow = 2.0 * tnsheath * v_th * nnsheath * dasheath;   // [W]
+                pump_neutral_energy_sink = pump_neutral_energy_flow / dv * (1 - multiplier);   // heatsink [W m^-3]
 
-                // Pump puts neutral particle and energy source in final domain cell
-                // Source accounts for recycled ions and the particle sink due to neutrals hitting the pump
-                // Note that the ions are explicitly transported out of the domain by anomalous_diffusion.cxx
-                // the pump picks this up and adds a recycling source based on this, but doesn't need an ion sink.
-                // Neutrals are not explicitly transported out by any component and must be taken out by the sink below.
-                // Pump multiplier controls both fraction of recycled ions and fraction of returned neutrals 
-                pump_recycle_density_source(mesh->xend, iy, iz) += recycle_source - psink;
-                pump_recycle_energy_source(mesh->xend, iy, iz) += recycle_source * channel.sol_energy - esink;
+                // Divide flows by volume to get sources
+                // Save to pump diagnostic
+                pump_density_source(mesh->xstart, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
+                pump_energy_source(mesh->xstart, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink;
+
+
               } else {
-                wall_recycle_density_source(mesh->xstart, iy, iz) += recycle_source;
-                wall_recycle_energy_source(mesh->xstart, iy, iz) += recycle_source * channel.pfr_energy;
+                // Save to wall diagnostic (pump sinks are 0 if not on pump)
+                wall_recycle_density_source(mesh->xstart, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
+                wall_recycle_energy_source(mesh->xstart, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink;   
+                 
               }
-            
-              // Add to density source which will be picked up by evolve_density.cxx
-              // Add to energy source which will be picked up by evolve_pressure.cxx
-              // psink and esink are additional sinks from the neutral pump which are 0 if disabled
-              density_source(mesh->xend, iy, iz) += recycle_source - psink;
-              energy_source(mesh->xend, iy, iz) += recycle_source * channel.pfr_energy - esink;
+
+              // Save to solver
+              density_source(mesh->xstart, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
+              energy_source(mesh->xstart, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink; 
 
             }
           }
         }
       }
+
     }
 
     // Put the updated sources back into the state
@@ -482,11 +567,11 @@ void Recycling::outputVars(Options& state) {
                           {"standard_name", "energy source"},
                           {"long_name", std::string("Wall recycling energy source of ") + channel.to},
                           {"source", "recycling"}});
-        }
+          }
 
         // Neutral pump
         if (neutral_pump) {
-          set_with_attrs(state[{std::string("S") + channel.to + std::string("_pump")}], pump_recycle_density_source,
+          set_with_attrs(state[{std::string("S") + channel.to + std::string("_pump")}], pump_density_source,
                           {{"time_dimension", "t"},
                           {"units", "m^-3 s^-1"},
                           {"conversion", Nnorm * Omega_ci},
@@ -494,7 +579,7 @@ void Recycling::outputVars(Options& state) {
                           {"long_name", std::string("Pump recycling particle source of ") + channel.to},
                           {"source", "recycling"}});
     
-          set_with_attrs(state[{std::string("E") + channel.to + std::string("_pump")}], pump_recycle_energy_source,
+          set_with_attrs(state[{std::string("E") + channel.to + std::string("_pump")}], pump_energy_source,
                           {{"time_dimension", "t"},
                           {"units", "W m^-3"},
                           {"conversion", Pnorm * Omega_ci},


### PR DESCRIPTION
Changes after discussion with Wim. Based on version D) https://github.com/mikekryjak/hermes-3/pull/4
Here particle, heat and momentum fluxes are calculated from the diffusive terms only (i.e. neglecting advection of density, heat and momentum in both parallel and perpendicular) and are applied on the diffusive terms only.

We also fix a previous omission: kappa and eta are calculated from D which is being limited by particle_flux_factor, but this wasn't in the code. Now eta and kappa are correctly multiplied by particle_flux_factor before further operations.