### PR TITLE
WIP, experimental: Try merging small cells into neighbouring cells

### DIFF
--- a/include/evolve_density.hxx
+++ b/include/evolve_density.hxx
@@ -93,6 +93,9 @@ private:
 
   bool diagnose; ///< Output additional diagnostics?
   Field3D flow_xlow, flow_ylow; ///< Particle flow diagnostics
+
+  bool merge_cells; ///< Merge neighboring cells
+  Region<Ind3D> merge_region; ///< Mark cells to merge
 };
 
 namespace {

--- a/include/evolve_energy.hxx
+++ b/include/evolve_energy.hxx
@@ -104,6 +104,9 @@ private:
   bool diagnose;      ///< Output additional diagnostics?
   bool enable_precon; ///< Enable preconditioner?
   Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
+
+  bool merge_cells; ///< Merge neighboring cells
+  Region<Ind3D> merge_region; ///< Mark cells to merge
 };
 
 namespace {

--- a/include/evolve_momentum.hxx
+++ b/include/evolve_momentum.hxx
@@ -54,6 +54,9 @@ private:
   bool diagnose; ///< Output additional diagnostics?
   bool fix_momentum_boundary_flux; ///< Fix momentum flux to boundary condition?
   Field3D flow_xlow, flow_ylow; ///< Momentum flow diagnostics
+
+  bool merge_cells; ///< Merge neighboring cells
+  Region<Ind3D> merge_region; ///< Mark cells to merge
 };
 
 namespace {

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -112,6 +112,9 @@ private:
   BoutReal time_normalisation; ///< Normalisation factor [s]
   bool source_time_dependent; ///< Is the input source time dependent?
   Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
+
+  bool merge_cells; ///< Merge neighboring cells
+  Region<Ind3D> merge_region; ///< Mark cells to merge
 };
 
 namespace {

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -101,6 +101,9 @@ private:
   Field3D momentum_flow_xlow, momentum_flow_ylow;
   Field3D energy_flow_xlow, energy_flow_ylow;
   Field3D conduction_flow_xlow, conduction_flow_ylow;
+
+  bool merge_cells; ///< Merge neighboring cells
+  Region<Ind3D> merge_region; ///< Mark cells to merge
 };
 
 namespace {

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -118,6 +118,28 @@ EvolveEnergy::EvolveEnergy(std::string name, Options& alloptions, Solver* solver
       alloptions[std::string("E") + name]["neumann_boundary_average_z"]
           .doc("Apply neumann boundary with Z average?")
           .withDefault<bool>(false);
+
+  merge_cells = options["merge_cells"]
+    .doc("Merge marked cells with their neighbors in Y")
+    .withDefault<bool>(false);
+  if (merge_cells) {
+    Field2D merge_mask2d;
+    if (mesh->get(merge_mask2d, "merge_mask") != 0) {
+      throw BoutException("Could not read merge_mask variable");
+    }
+    Field3D merge_mask = merge_mask2d;
+
+    // Find every cell that has merge_mask > 0
+    // so we can efficiently iterate over them later
+    Region<Ind3D>::RegionIndices indices;
+    BOUT_FOR_SERIAL(i, merge_mask.getRegion("RGN_NOBNDRY")) {
+      if (merge_mask[i] > 1e-5) {
+        // Add this cell to the iteration
+        indices.push_back(i);
+      }
+    }
+    merge_region = Region<Ind3D>(indices);
+  }
 }
 
 void EvolveEnergy::transform(Options& state) {
@@ -349,6 +371,34 @@ void EvolveEnergy::finally(const Options& state) {
   // Scale time derivatives
   if (state.isSet("scale_timederivs")) {
     ddt(E) *= get<Field3D>(state["scale_timederivs"]);
+  }
+
+  if (merge_cells) {
+    mesh->communicate(ddt(E));
+    const auto coord = E.getCoordinates();
+
+    // Merge neighbouring cells in Y
+    BOUT_FOR(i, merge_region) {
+      // Average with neighbors, weighted by cell volume
+      // Half of the cell with each neighbour
+      auto im = i.ym();
+      auto ip = i.yp();
+
+      // Volume of neighouring cells
+      BoutReal Vc = coord->J[i] * coord->dy[i];
+      BoutReal Vm = coord->J[im] * coord->dy[im];
+      BoutReal Vp = coord->J[ip] * coord->dy[ip];
+
+      // Half of the central cell is merged with each side
+      ddt(E)[im] = (0.5 * Vc * ddt(E)[i] + Vm * ddt(E)[im]) /
+        (0.5 * Vc + Vm);
+
+      ddt(E)[ip] = (0.5 * Vc * ddt(E)[i] + Vp * ddt(E)[ip]) /
+        (0.5 * Vc + Vp);
+
+      // Central cell is average of either side
+      ddt(E)[i] = 0.5 * (ddt(E)[im] + ddt(E)[ip]);
+    }
   }
 
   if (evolve_log) {

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -61,6 +61,28 @@ EvolveMomentum::EvolveMomentum(std::string name, Options &alloptions, Solver *so
 
   // Set to zero so set for output
   momentum_source = 0.0;
+
+  merge_cells = options["merge_cells"]
+    .doc("Merge marked cells with their neighbors in Y")
+    .withDefault<bool>(false);
+  if (merge_cells) {
+    Field2D merge_mask2d;
+    if (mesh->get(merge_mask2d, "merge_mask") != 0) {
+      throw BoutException("Could not read merge_mask variable");
+    }
+    Field3D merge_mask = merge_mask2d;
+
+    // Find every cell that has merge_mask > 0
+    // so we can efficiently iterate over them later
+    Region<Ind3D>::RegionIndices indices;
+    BOUT_FOR_SERIAL(i, merge_mask.getRegion("RGN_NOBNDRY")) {
+      if (merge_mask[i] > 1e-5) {
+        // Add this cell to the iteration
+        indices.push_back(i);
+      }
+    }
+    merge_region = Region<Ind3D>(indices);
+  }
 }
 
 void EvolveMomentum::transform(Options &state) {
@@ -180,6 +202,34 @@ void EvolveMomentum::finally(const Options &state) {
   // Scale time derivatives
   if (state.isSet("scale_timederivs")) {
     ddt(NV) *= get<Field3D>(state["scale_timederivs"]);
+  }
+
+  if (merge_cells) {
+    mesh->communicate(ddt(NV));
+    const auto coord = NV.getCoordinates();
+
+    // Merge neighbouring cells in Y
+    BOUT_FOR(i, merge_region) {
+      // Average with neighbors, weighted by cell volume
+      // Half of the cell with each neighbour
+      auto im = i.ym();
+      auto ip = i.yp();
+
+      // Volume of neighouring cells
+      BoutReal Vc = coord->J[i] * coord->dy[i];
+      BoutReal Vm = coord->J[im] * coord->dy[im];
+      BoutReal Vp = coord->J[ip] * coord->dy[ip];
+
+      // Half of the central cell is merged with each side
+      ddt(NV)[im] = (0.5 * Vc * ddt(NV)[i] + Vm * ddt(NV)[im]) /
+        (0.5 * Vc + Vm);
+
+      ddt(NV)[ip] = (0.5 * Vc * ddt(NV)[i] + Vp * ddt(NV)[ip]) /
+        (0.5 * Vc + Vp);
+
+      // Central cell is average of either side
+      ddt(NV)[i] = 0.5 * (ddt(NV)[im] + ddt(NV)[ip]);
+    }
   }
 
 #if CHECKLEVEL >= 1

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -153,6 +153,27 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
     .doc("Apply neumann boundary with Z average?")
     .withDefault<bool>(false);
 
+  merge_cells = options["merge_cells"]
+    .doc("Merge marked cells with their neighbors in Y")
+    .withDefault<bool>(false);
+  if (merge_cells) {
+    Field2D merge_mask2d;
+    if (mesh->get(merge_mask2d, "merge_mask") != 0) {
+      throw BoutException("Could not read merge_mask variable");
+    }
+    Field3D merge_mask = merge_mask2d;
+
+    // Find every cell that has merge_mask > 0
+    // so we can efficiently iterate over them later
+    Region<Ind3D>::RegionIndices indices;
+    BOUT_FOR_SERIAL(i, merge_mask.getRegion("RGN_NOBNDRY")) {
+      if (merge_mask[i] > 1e-5) {
+        // Add this cell to the iteration
+        indices.push_back(i);
+      }
+    }
+    merge_region = Region<Ind3D>(indices);
+  }
 }
 
 void EvolvePressure::transform(Options& state) {
@@ -457,6 +478,34 @@ void EvolvePressure::finally(const Options& state) {
   // Scale time derivatives
   if (state.isSet("scale_timederivs")) {
     ddt(P) *= get<Field3D>(state["scale_timederivs"]);
+  }
+
+  if (merge_cells) {
+    mesh->communicate(ddt(P));
+    const auto coord = P.getCoordinates();
+
+    // Merge neighbouring cells in Y
+    BOUT_FOR(i, merge_region) {
+      // Average with neighbors, weighted by cell volume
+      // Half of the cell with each neighbour
+      auto im = i.ym();
+      auto ip = i.yp();
+
+      // Volume of neighouring cells
+      BoutReal Vc = coord->J[i] * coord->dy[i];
+      BoutReal Vm = coord->J[im] * coord->dy[im];
+      BoutReal Vp = coord->J[ip] * coord->dy[ip];
+
+      // Half of the central cell is merged with each side
+      ddt(P)[im] = (0.5 * Vc * ddt(P)[i] + Vm * ddt(P)[im]) /
+        (0.5 * Vc + Vm);
+
+      ddt(P)[ip] = (0.5 * Vc * ddt(P)[i] + Vp * ddt(P)[ip]) /
+        (0.5 * Vc + Vp);
+
+      // Central cell is average of either side
+      ddt(P)[i] = 0.5 * (ddt(P)[im] + ddt(P)[ip]);
+    }
   }
 
   if (evolve_log) {

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -236,6 +236,28 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
   DnnNn.setBoundary(std::string("Dnn") + name);
   DnnPn.setBoundary(std::string("Dnn") + name);
   DnnNVn.setBoundary(std::string("Dnn") + name);
+
+  merge_cells = options["merge_cells"]
+    .doc("Merge marked cells with their neighbors in Y")
+    .withDefault<bool>(false);
+  if (merge_cells) {
+    Field2D merge_mask2d;
+    if (mesh->get(merge_mask2d, "merge_mask") != 0) {
+      throw BoutException("Could not read merge_mask variable");
+    }
+    Field3D merge_mask = merge_mask2d;
+
+    // Find every cell that has merge_mask > 0
+    // so we can efficiently iterate over them later
+    Region<Ind3D>::RegionIndices indices;
+    BOUT_FOR_SERIAL(i, merge_mask.getRegion("RGN_NOBNDRY")) {
+      if (merge_mask[i] > 1e-5) {
+        // Add this cell to the iteration
+        indices.push_back(i);
+      }
+    }
+    merge_region = Region<Ind3D>(indices);
+  }
 }
 
 void NeutralMixed::transform(Options& state) {
@@ -809,10 +831,50 @@ void NeutralMixed::finally(const Options& state) {
   }
 #endif
 
-if (first_rhs) {
+  if (first_rhs) {
     first_rhs = false;
   }
 
+  if (merge_cells) {
+    mesh->communicate(ddt(Nn), ddt(Pn), ddt(NVn));
+
+    const auto coord = NVn.getCoordinates();
+
+    // Merge neighbouring cells in Y
+    BOUT_FOR(i, merge_region) {
+      // Average with neighbors, weighted by cell volume
+      // Half of the cell with each neighbour
+      auto im = i.ym();
+      auto ip = i.yp();
+
+      // Volume of neighouring cells
+      BoutReal Vc = coord->J[i] * coord->dy[i];
+      BoutReal Vm = coord->J[im] * coord->dy[im];
+      BoutReal Vp = coord->J[ip] * coord->dy[ip];
+      
+      // Half of the central cell is merged with each side
+      ddt(Nn)[im] = (0.5 * Vc * ddt(Nn)[i] + Vm * ddt(Nn)[im]) /
+        (0.5 * Vc + Vm);
+
+      ddt(Nn)[ip] = (0.5 * Vc * ddt(Nn)[i] + Vp * ddt(Nn)[ip]) /
+        (0.5 * Vc + Vp);
+
+      // Central cell is average of either side
+      ddt(Nn)[i] = 0.5 * (ddt(Nn)[im] + ddt(Nn)[ip]);
+
+      ddt(Pn)[im] = (0.5 * Vc * ddt(Pn)[i] + Vm * ddt(Pn)[im]) /
+        (0.5 * Vc + Vm);
+      ddt(Pn)[ip] = (0.5 * Vc * ddt(Pn)[i] + Vp * ddt(Pn)[ip]) /
+        (0.5 * Vc + Vp);
+      ddt(Pn)[i] = 0.5 * (ddt(Pn)[im] + ddt(Pn)[ip]);
+
+      ddt(NVn)[im] = (0.5 * Vc * ddt(NVn)[i] + Vm * ddt(NVn)[im]) /
+        (0.5 * Vc + Vm);
+      ddt(NVn)[ip] = (0.5 * Vc * ddt(NVn)[i] + Vp * ddt(NVn)[ip]) /
+        (0.5 * Vc + Vp);
+      ddt(NVn)[i] = 0.5 * (ddt(NVn)[im] + ddt(NVn)[ip]);
+    }
+  }
 }
 
 void NeutralMixed::outputVars(Options& state) {


### PR DESCRIPTION
Reads a mask from the mesh file. Cells that are marked are merged with their neighbours. Takes into account cell volume in the averaging.

- If option "merge_cells" is `true`, read a field `merge_mask` from the mesh file
- Cells with `merge_mask > 1e-5` are stored in a region
- The time derivatives of N, P and NV in these marked cells are merged with their neighbours in the Y (poloidal) direction: The cell is split in two, each side is averaged with its neighbour, and then the marked cell is the average.
This takes account of the volume of the cell, so e.g. particle content should be preserved.
 