### PR TITLE
Scale kappa_par in core rings

### DIFF
--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -95,6 +95,8 @@ private:
   bool low_p_diffuse_perp; ///< Add artificial cross-field diffusion at low electron pressure?
 
   Field3D kappa_par; ///< Parallel heat conduction coefficient
+  BoutReal core_kappa_factor;   ///< Scaling factor on first core ring conduction
+  int core_kappa_scale_rings;   ///< Number of rings to scale conduction by core_kappa_factor
 
   Field3D source, final_source; ///< External pressure source
   Field3D Sp;     ///< Total pressure source


### PR DESCRIPTION
Done to try and suppress mesh seam fluctuations. This works successfully but the fluctuations appear to be driven my ion momentum after all.

Settings:
- **core_kappa_factor:** scale kappa_par by this amount
- **core_kappa_scale_rings:** do it over this many rings starting from the first core ring